### PR TITLE
feat: restrict image to vertical view and support arrow keys

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -27,8 +27,18 @@ body {
   background: #e0e0e0;
   position: relative;
 }
+#imageContainer {
+  width: 500px;
+  height: 800px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 .level-image {
-  max-height: 90%;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   transform: rotateY(0deg);
   transition: transform 0.5s ease;
 }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,9 @@
         <button onclick="rotateLeft()">⟵</button>
         <button onclick="rotateRight()">⟶</button>
       </div>
-      <img id="levelImage" class="level-image" src="" alt="Vista del nivel" />
+      <div id="imageContainer">
+        <img id="levelImage" class="level-image" src="" alt="Vista del nivel" />
+      </div>
     </div>
   </div>
   <script>
@@ -60,6 +62,13 @@
       rotation += 30;
       document.getElementById("levelImage").style.transform = `rotateY(${rotation}deg)`;
     }
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowLeft') {
+        rotateLeft();
+      } else if (e.key === 'ArrowRight') {
+        rotateRight();
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Limit level viewer to 500x800 vertical frame
- Add keyboard arrow support for left/right rotation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eaf66c9c8320955f3bc256f2a59c