### PR TITLE
Implement cylindrical level scrolling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -31,16 +31,10 @@ body {
   width: 500px;
   height: 800px;
   overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.level-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transform: rotateY(0deg);
-  transition: transform 0.5s ease;
+  background-repeat: repeat-x;
+  background-size: auto 100%;
+  background-position: 0 0;
+  transition: background-position 0.5s ease;
 }
 button {
   background: orange;

--- a/index.html
+++ b/index.html
@@ -23,15 +23,20 @@
         <button onclick="rotateLeft()">⟵</button>
         <button onclick="rotateRight()">⟶</button>
       </div>
-      <div id="imageContainer">
-        <img id="levelImage" class="level-image" src="" alt="Vista del nivel" />
-      </div>
+        <div id="imageContainer"></div>
     </div>
   </div>
   <script>
     const version = "1.0.0";
     const buildTime = "2025-08-21 11:00 CEST";
+    const imageContainer = document.getElementById("imageContainer");
+    const imageWidth = 2000; // width of level images in pixels
     let rotation = 0;
+
+    function updateView() {
+      const offset = (rotation / 360) * imageWidth;
+      imageContainer.style.backgroundPosition = `${-offset}px 0`;
+    }
 
     fetch("data/levels.json?v=" + version)
       .then(res => res.json())
@@ -43,24 +48,24 @@
           option.textContent = level.name;
           selector.appendChild(option);
         });
-        if (data.levels.length > 0) {
-          document.getElementById("levelImage").src = data.levels[0].image + "?v=" + version;
-        }
-      });
+          if (data.levels.length > 0) {
+            imageContainer.style.backgroundImage = `url(${data.levels[0].image}?v=${version})`;
+          }
+        });
 
     document.getElementById("levelSelector").addEventListener("change", (e) => {
-      document.getElementById("levelImage").src = e.target.value;
+      imageContainer.style.backgroundImage = `url(${e.target.value})`;
       rotation = 0;
-      document.getElementById("levelImage").style.transform = `rotateY(0deg)`;
+      imageContainer.style.backgroundPosition = "0 0";
     });
 
     function rotateLeft() {
-      rotation -= 30;
-      document.getElementById("levelImage").style.transform = `rotateY(${rotation}deg)`;
+      rotation = (rotation - 30 + 360) % 360;
+      updateView();
     }
     function rotateRight() {
-      rotation += 30;
-      document.getElementById("levelImage").style.transform = `rotateY(${rotation}deg)`;
+      rotation = (rotation + 30) % 360;
+      updateView();
     }
     document.addEventListener('keydown', (e) => {
       if (e.key === 'ArrowLeft') {


### PR DESCRIPTION
## Summary
- Show levels as a horizontally wrapping background instead of rotating the image in 3D
- Add JS logic to translate background position for left/right controls

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ee0a91f88320bf3dbd39ac290057