### PR TITLE
Fix level view shrinking bug

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -44,6 +44,7 @@ body {
 .level {
   width: 100%;
   height: 100%;
+  flex: 0 0 100%;
   background-repeat: repeat-x;
   background-size: auto 100%;
   background-position: 0 0;


### PR DESCRIPTION
## Summary
- prevent level images from shrinking so each level retains full height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fc40c8c08320940041d16abd479d