### PR TITLE
Fix extra rotation after releasing arrow keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     let moveInterval = null;
     const MOVE_STEP = 2; // percentage per step
     let rotateInterval = null;
+    let rotateDirection = 0;
     const ROTATE_STEP = 5; // degrees per step
     let levels = [];
 
@@ -101,16 +102,21 @@
     }
 
     function startRotate(direction) {
+      rotateDirection = direction;
       rotation += direction * ROTATE_STEP;
       updateView();
-      if (rotateInterval) return;
-      rotateInterval = setInterval(() => {
-        rotation += direction * ROTATE_STEP;
-        updateView();
-      }, 20);
+      if (!rotateInterval) {
+        rotateInterval = setInterval(() => {
+          if (rotateDirection !== 0) {
+            rotation += rotateDirection * ROTATE_STEP;
+            updateView();
+          }
+        }, 20);
+      }
     }
 
     function stopRotate() {
+      rotateDirection = 0;
       if (rotateInterval) {
         clearInterval(rotateInterval);
         rotateInterval = null;
@@ -155,9 +161,9 @@
 
     document.addEventListener('keydown', (e) => {
       if (e.key === 'ArrowLeft') {
-        if (!rotateInterval) startRotate(-1);
+        if (rotateDirection === 0) startRotate(-1);
       } else if (e.key === 'ArrowRight') {
-        if (!rotateInterval) startRotate(1);
+        if (rotateDirection === 0) startRotate(1);
       } else if (e.key === 'ArrowUp') {
         if (!moveInterval) startVerticalMove(-1);
       } else if (e.key === 'ArrowDown') {


### PR DESCRIPTION
## Summary
- Ensure horizontal rotation stops immediately when releasing arrow keys
- Track current rotation direction to avoid stray steps after keyup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a70a56023c8320a12dd20074d71374