### PR TITLE
Fix horizontal movement to stop immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,6 @@
     let moveInterval = null;
     const MOVE_STEP = 2; // percentage per step
     let rotateInterval = null;
-    let rotateDirection = 0;
     const ROTATE_STEP = 5; // degrees per step
     let levels = [];
 
@@ -102,21 +101,16 @@
     }
 
     function startRotate(direction) {
-      rotateDirection = direction;
       rotation += direction * ROTATE_STEP;
       updateView();
-      if (!rotateInterval) {
-        rotateInterval = setInterval(() => {
-          if (rotateDirection !== 0) {
-            rotation += rotateDirection * ROTATE_STEP;
-            updateView();
-          }
-        }, 20);
-      }
+      if (rotateInterval) return;
+      rotateInterval = setInterval(() => {
+        rotation += direction * ROTATE_STEP;
+        updateView();
+      }, 20);
     }
 
     function stopRotate() {
-      rotateDirection = 0;
       if (rotateInterval) {
         clearInterval(rotateInterval);
         rotateInterval = null;
@@ -161,9 +155,9 @@
 
     document.addEventListener('keydown', (e) => {
       if (e.key === 'ArrowLeft') {
-        if (rotateDirection === 0) startRotate(-1);
+        if (!rotateInterval) startRotate(-1);
       } else if (e.key === 'ArrowRight') {
-        if (rotateDirection === 0) startRotate(1);
+        if (!rotateInterval) startRotate(1);
       } else if (e.key === 'ArrowUp') {
         if (!moveInterval) startVerticalMove(-1);
       } else if (e.key === 'ArrowDown') {


### PR DESCRIPTION
## Summary
- Remove stale `rotateDirection` state and simplify rotation logic to stop instantly when releasing left or right controls.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a70e2784248320b27b3ebcdda173d5