### PR TITLE
Fix extra lateral movement after key release

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,9 +88,10 @@
     }
 
     function startVerticalMove(direction) {
-      moveVertical(direction * MOVE_STEP);
       if (moveInterval) return;
-      moveInterval = setInterval(() => moveVertical(direction * MOVE_STEP), 20);
+      const step = () => moveVertical(direction * MOVE_STEP);
+      step();
+      moveInterval = setInterval(step, 20);
     }
 
     function stopVerticalMove() {
@@ -101,13 +102,13 @@
     }
 
     function startRotate(direction) {
-      rotation += direction * ROTATE_STEP;
-      updateView();
       if (rotateInterval) return;
-      rotateInterval = setInterval(() => {
+      const step = () => {
         rotation += direction * ROTATE_STEP;
         updateView();
-      }, 20);
+      };
+      step();
+      rotateInterval = setInterval(step, 20);
     }
 
     function stopRotate() {


### PR DESCRIPTION
## Summary
- Prevent repeated key presses from triggering additional rotation or vertical movement
- Ensure movement stops immediately when controls are released

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7189c067083209f7380ac9c4bc2d0