### PR TITLE
Translate interface to English and add level titles

### DIFF
--- a/data/worlds.json
+++ b/data/worlds.json
@@ -1,20 +1,20 @@
 {
-  "version": "1.0.0",
-  "buildTime": "2025-08-21 12:26 CEST",
+  "version": "1.1.0",
+  "buildTime": "2025-08-25 16:08 CEST",
   "worlds": [
     {
-      "name": "Mundo 1",
+      "name": "World 1",
       "levels": [
-        {"name": "level_01-01", "image": "assets/level_01-01.png"},
-        {"name": "level_01-02", "image": "assets/level_01-02.png"},
-        {"name": "level_01-03", "image": "assets/level_01-03.png"}
+        {"name": "level_01-01", "displayName": "Level 1-1", "image": "assets/level_01-01.png"},
+        {"name": "level_01-02", "displayName": "Level 1-2", "image": "assets/level_01-02.png"},
+        {"name": "level_01-03", "displayName": "Level 1-3", "image": "assets/level_01-03.png"}
       ]
     },
     {
-      "name": "Mundo 2",
+      "name": "World 2",
       "levels": [
-        {"name": "level_02-01", "image": "assets/level_02-01.png"},
-        {"name": "level_02-02", "image": "assets/level_02-02.png"}
+        {"name": "level_02-01", "displayName": "Level 2-1", "image": "assets/level_02-01.png"},
+        {"name": "level_02-02", "displayName": "Level 2-2", "image": "assets/level_02-02.png"}
       ]
     }
   ]

--- a/index.html
+++ b/index.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>LevelViewerSystem</title>
-  <link rel="stylesheet" href="assets/styles.css?v=1.0.0">
+  <link rel="stylesheet" href="assets/styles.css?v=1.1.0">
 </head>
 <body>
   <div id="container">
     <div id="sidebar">
       <div>
-        <h2>Niveles</h2>
+        <h2>Levels</h2>
         <div id="worldList"></div>
       </div>
       <div class="version-box">
-        Versión: 1.0.0<br>
-        Build: 2025-08-21 12:26 CEST
+        Version: 1.1.0<br>
+        Build: 2025-08-25 16:08 CEST
       </div>
     </div>
     <div id="viewer">
@@ -37,8 +37,8 @@
     </div>
   </div>
   <script>
-    const version = "1.0.0";
-    const buildTime = "2025-08-21 12:26 CEST";
+    const version = "1.1.0";
+    const buildTime = "2025-08-25 16:08 CEST";
     const worldList = document.getElementById("worldList");
     const levelStack = document.getElementById("levelStack");
     const imageWidth = 2000; // width of level images in pixels
@@ -168,7 +168,7 @@
 
           world.levels.forEach((level, idx) => {
             const li = document.createElement('li');
-            li.textContent = level.name;
+            li.textContent = level.displayName;
             const domIndex = world.levels.length - 1 - idx;
             li.addEventListener('click', () => {
               if (currentWorld === worldIndex) {


### PR DESCRIPTION
## Summary
- Switch UI text from Spanish to English, including version info
- Bump version to 1.1.0 with current build timestamp
- Introduce `displayName` for levels and update world names

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6dee576883208dcc596999b8ad4e